### PR TITLE
Rewrite parser to read mod.info files, assure backwards compatibility and add small color changes

### DIFF
--- a/media/lua/client/tiny_avc.lua
+++ b/media/lua/client/tiny_avc.lua
@@ -355,19 +355,16 @@ function TinyAVCWindow:doDrawItem(y, item, alt) -- {{{
 
 	local x = 8;
 	if item.url ~= nil then
-		local r = 1;
-		local g = 1;
-		local b = 1;
-		local a = 1;
+		local r, g, b, a = 1, 1, 1, 1;
 		if item.latestVersion ~= item.version then
-			r = 0;
-			g = 1;
-			b = 0;
+			self:drawText(item.name,                         x, 2 + y,   r, 0.6, 0.0, a);
+			self:drawText(item.version,       self.width*0.6+x, 2 + y,   r, 0.6, 0.0, a);
+			self:drawText(item.latestVersion, self.width*0.7+x, 2 + y, 0.0,   g, 0.0, a);
+		else
+			self:drawText(item.name,                         x, 2 + y, r, g, b, a);
+			self:drawText(item.version,       self.width*0.6+x, 2 + y, r, g, b, a);
+			self:drawText(item.latestVersion, self.width*0.7+x, 2 + y, r, g, b, a);
 		end
-
-		self:drawText(item.name,                         x, 2+y, r, g, b, a);
-		self:drawText(item.version,       self.width*0.6+x, 2+y, r, g, b, a);
-		self:drawText(item.latestVersion, self.width*0.7+x, 2+y, r, g, b, a);
 		self:drawText(item.minVersion,    self.width*0.8+x, 2+y, r, g, b, a);
 
 		local line2 = nil;

--- a/media/lua/client/tiny_avc.lua
+++ b/media/lua/client/tiny_avc.lua
@@ -460,6 +460,58 @@ local TAG_VERSION_URL = "versionurl=";
 local TAG_MOD_URL     = "modurl=";
 local TAG_DELIMITER   = "=";
 
+-- @deprecated Will be removed in future versions.
+local function assureBackwardsCompatibility(mod)
+	TinyAVC.checked = true;
+	TinyAVC.content = "";
+	local list = getModDirectoryTable();
+	for _,mod in pairs(list) do
+		TinyAVC.mods[mod] = {};
+		local f = getFileInput("..".."/".."mods".."/"..mod.."/".."tiny_avc.txt");
+		if f ~= nil then
+			local line = f:readLine();
+			while line ~= nil do
+				if string.starts(line, "version:") then
+					local r = string.split(line, ":");
+					TinyAVC.mods[mod].version = r[2];
+				end
+				if string.starts(line, "url:") then
+					local r = string.split(line, ":")
+					TinyAVC.mods[mod].url = r[2]..":"..r[3];
+				end
+				line = f:readLine();
+			end
+			f:close();
+		end
+
+		if TinyAVC.mods[mod].url ~= nil then
+			TinyAVC.mods[mod].latestVersion = "ERR";
+			TinyAVC.mods[mod].minVersion = "ERR";
+			TinyAVC.mods[mod].srcUrl = "ERR";
+			local content = TinyAVC.getUrl(TinyAVC.mods[mod].url);
+			--[[ Format is:
+			--version:0.9.5
+			--minVersion:30.16
+			--url:http://theindiestone.com/forums/index.php/topic/10952-dirty-water-and-saltwater-get-sick-by-drinking-from-the-toilet-rain-barrel-collect-water-from-rivers/
+			--]]
+			for _,line in pairs(string.split(content, "\n")) do
+				if string.starts(line, "version:") then
+					local r = string.split(line, ":");
+					TinyAVC.mods[mod].latestVersion = r[2];
+				end
+				if string.starts(line, "minVersion:") then
+					local r = string.split(line, ":");
+					TinyAVC.mods[mod].minVersion = r[2];
+				end
+				if string.starts(line, "url:") then
+					local r = string.split(line, ":");
+					TinyAVC.mods[mod].srcUrl = r[2]..":"..r[3];
+				end
+			end
+		end
+	end
+end
+
 function TinyAVCWindow:downloadUpdates() -- {{{
 	if TinyAVC.checked then return end;
 
@@ -518,6 +570,11 @@ function TinyAVCWindow:downloadUpdates() -- {{{
 					TinyAVC.mods[mod].srcUrl = snippet[2];
 				end
 			end
+		end
+
+		-- @deprecated Will be removed in future versions.
+		if TinyAVC.mods[mod].latestVersion == "ERR" or TinyAVC.mods[mod].minVersion == 'ERR' or TinyAVC.mods[mod].srcUrl == 'ERR' then
+			assureBackwardsCompatibility(mod);
 		end
 	end
 end

--- a/mod.info
+++ b/mod.info
@@ -2,3 +2,8 @@ name=tiny Automated Version Checker
 poster=empty.png
 description=Automated mod version checker.
 id=tiny_avc
+
+modversion=0.7.0
+pzversion=32.2
+versionurl=https://raw.githubusercontent.com/blind-coder/pz-tiny_avc/master/mod.info
+modurl=http://theindiestone.com/forums/index.php/topic/13014-tiny-automated-version-checker-tiny-avc-070


### PR DESCRIPTION
Removed latest_version.txt and tiny_avc.txt and added the necessary tags
to the mod.info file. Moved tag and delimiter definitions to constants
outside of the function.

Updated the downloadUpdates() function to first load the tags from the
local mod.info file. It will then use the modurl tag in that file to
grab a file online which contains the version infos.

---

Assure backwards compatibility

If the version infos couldn't be loaded from the mod.info it will try to
load them from the old tiny_avc.txt instead.

I marked the code with "deprecated" tags so they can be easily removed
later on.

---

Use custom colors to highlight mods which need updating

The mod name and currently installed version will be displayed orange,
whereas the latest version is drawn in green.
